### PR TITLE
2.0.0 – migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.0] - 27/07/2021
+
+* Migrate to null safety
+
 ## [1.1.1] - 10/12/2020
 
 * Fix IOS

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -7,3 +7,4 @@
 build/
 
 .flutter-plugins
+.flutter-plugins-dependencies

--- a/example/ios/.gitignore
+++ b/example/ios/.gitignore
@@ -39,6 +39,7 @@ Icon?
 /Flutter/App.framework
 /Flutter/Flutter.framework
 /Flutter/Generated.xcconfig
+/Flutter/flutter_export_environment.sh
 /ServiceDefinitions.json
 
 Pods/

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  String path;
+  String? path;
 
   Future<String> get _localPath async {
     final directory = await getApplicationDocumentsDirectory();
@@ -44,8 +44,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<Uint8List> fetchPost() async {
-    final response = await http.get(
-        'https://expoforest.com.br/wp-content/uploads/2017/05/exemplo.pdf');
+    final response = await http.get(Uri.parse('https://expoforest.com.br/wp-content/uploads/2017/05/exemplo.pdf'));
     final responseJson = response.bodyBytes;
 
     return responseJson;
@@ -80,7 +79,7 @@ class _MyAppState extends State<MyApp> {
                 )
               else
                 Text("Pdf is not Loaded"),
-              RaisedButton(
+              ElevatedButton(
                 child: Text("Load pdf"),
                 onPressed: loadPdf,
               ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,63 +7,63 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   ffi:
     dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.1.2"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.1"
+    version: "6.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,112 +80,105 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0+2"
+    version: "0.13.3"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.4.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.24"
+    version: "2.0.2"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.1+2"
+    version: "2.0.0"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+6"
+    version: "2.0.0"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+3"
+    version: "2.0.1"
   pdf_viewer_plugin:
     dependency: "direct dev"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.1.1"
+    version: "2.0.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
+    version: "1.11.1"
   platform:
     dependency: transitive
     description:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.0.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.1"
   process:
     dependency: transitive
     description:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.13"
+    version: "4.2.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -197,70 +190,70 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.4.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   win32:
     dependency: transitive
     description:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.4"
+    version: "2.2.5"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.2.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.12.13+hotfix.6 <2.0.0"
+  dart: ">=2.13.0 <3.0.0"
+  flutter: ">=1.20.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,12 +1,15 @@
 name: pdf_viewer_plugin_example
 description: Demonstrates how to use the pdf_viewer_plugin plugin.
 
+environment:
+  sdk: ">=2.12.0-0 <3.0.0"
+
 dependencies:
   flutter:
     sdk: flutter
 
-  path_provider: ^1.6.24
-  http: any
+  path_provider: ^2.0.2
+  http: ^0.13.3
 
 dev_dependencies:
   flutter_test:

--- a/lib/pdf_viewer_plugin.dart
+++ b/lib/pdf_viewer_plugin.dart
@@ -14,7 +14,7 @@ class CreationParams {
     this.path,
   });
 
-  final String path;
+  final String? path;
 
   @override
   String toString() {
@@ -24,18 +24,18 @@ class CreationParams {
 
 abstract class PdfViewerPlatform {
   Widget build({
-    BuildContext context,
-    CreationParams creationParams,
-    Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
+    BuildContext? context,
+    CreationParams? creationParams,
+    Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers,
   });
 }
 
 class SurfaceAndroidPdfViewer extends AndroidPdfViewer {
   @override
   Widget build({
-    BuildContext context,
-    CreationParams creationParams,
-    Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers,
+    BuildContext? context,
+    CreationParams? creationParams,
+    Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers,
   }) {
     return PlatformViewLink(
       viewType: 'pdf_viewer_plugin',
@@ -44,7 +44,7 @@ class SurfaceAndroidPdfViewer extends AndroidPdfViewer {
         PlatformViewController controller,
       ) {
         return AndroidViewSurface(
-          controller: controller,
+          controller: controller as AndroidViewController,
           gestureRecognizers: gestureRecognizers ??
               const <Factory<OneSequenceGestureRecognizer>>{},
           hitTestBehavior: PlatformViewHitTestBehavior.opaque,
@@ -56,7 +56,7 @@ class SurfaceAndroidPdfViewer extends AndroidPdfViewer {
           viewType: 'pdf_viewer_plugin',
           layoutDirection: TextDirection.rtl,
           creationParams: MethodChannelPdfViewerPlatform.creationParamsToMap(
-            creationParams,
+            creationParams!,
           ),
           creationParamsCodec: const StandardMessageCodec(),
         )
@@ -71,13 +71,13 @@ class SurfaceAndroidPdfViewer extends AndroidPdfViewer {
 class PdfView extends StatefulWidget {
   /// Creates a new web view.
   const PdfView({
-    Key key,
+    Key? key,
     this.path,
     this.gestureRecognizers,
     this.gestureNavigationEnabled = false,
   }) : super(key: key);
 
-  static PdfViewerPlatform _platform;
+  static PdfViewerPlatform? _platform;
 
   /// Sets a custom [PdfViewerPlatform].
   ///
@@ -86,14 +86,14 @@ class PdfView extends StatefulWidget {
   /// Setting `platform` doesn't affect [PdfView]s that were already created.
   ///
   /// The default value is [AndroidPdfViewer] on Android and [CupertinoPdfViewer] on iOS.
-  static set platform(PdfViewerPlatform platform) {
+  static set platform(PdfViewerPlatform? platform) {
     _platform = platform;
   }
 
   /// The WebView platform that's used by this WebView.
   ///
   /// The default value is [AndroidPdfViewer] on Android and [CupertinoPdfViewer] on iOS.
-  static PdfViewerPlatform get platform {
+  static PdfViewerPlatform? get platform {
     if (_platform == null) {
       switch (defaultTargetPlatform) {
         case TargetPlatform.android:
@@ -119,10 +119,10 @@ class PdfView extends StatefulWidget {
   ///
   /// When this set is empty or null, the web view will only handle pointer events for gestures that
   /// were not claimed by any other gesture recognizer.
-  final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
+  final Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers;
 
   /// The initial path to load.
-  final String path;
+  final String? path;
 
   /// A Boolean value indicating whether horizontal swipe gestures will trigger back-forward list navigations.
   ///
@@ -138,7 +138,7 @@ class PdfView extends StatefulWidget {
 class _PdfViewState extends State<PdfView> {
   @override
   Widget build(BuildContext context) {
-    return PdfView.platform.build(
+    return PdfView.platform!.build(
       context: context,
       gestureRecognizers: widget.gestureRecognizers,
       creationParams: _creationParamsfromWidget(widget),

--- a/lib/src/android_pdf_viewer.dart
+++ b/lib/src/android_pdf_viewer.dart
@@ -1,0 +1,45 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:pdf_viewer_plugin/src/pdf_viewer_method_channel.dart';
+
+import '../pdf_viewer_plugin.dart';
+
+/// Builds an Android pdfview.
+///
+/// This is used as the default implementation for [PdfView.platform] on Android. It uses
+/// an [AndroidView] to embed the pdfview in the widget hierarchy, and uses a method channel to
+/// communicate with the platform code.
+class AndroidPdfViewer implements PdfViewerPlatform {
+  @override
+  Widget build({
+    BuildContext? context,
+    CreationParams? creationParams,
+    Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers,
+  }) {
+    return GestureDetector(
+      // We prevent text selection by intercepting the long press event.
+      // This is a temporary stop gap due to issues with text selection on Android:
+      // https://github.com/flutter/flutter/issues/24585 - the text selection
+      // dialog is not responding to touch events.
+      // https://github.com/flutter/flutter/issues/24584 - the text selection
+      // handles are not showing.
+      // TODO(amirh): remove this when the issues above are fixed.
+      onLongPress: () {},
+      excludeFromSemantics: true,
+      child: AndroidView(
+        viewType: 'pdf_viewer_plugin',
+        onPlatformViewCreated: (int id) {},
+        gestureRecognizers: gestureRecognizers,
+        layoutDirection: TextDirection.rtl,
+        creationParams:
+            MethodChannelPdfViewerPlatform.creationParamsToMap(creationParams!),
+        creationParamsCodec: const StandardMessageCodec(),
+      ),
+    );
+  }
+}

--- a/lib/src/cupertino_pfd_viewer.dart
+++ b/lib/src/cupertino_pfd_viewer.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:pdf_viewer_plugin/src/pdf_viewer_method_channel.dart';
+
+import '../pdf_viewer_plugin.dart';
+
+class CupertinoPdfViewer implements PdfViewerPlatform {
+  @override
+  Widget build({
+    BuildContext? context,
+    CreationParams? creationParams,
+    Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers,
+  }) {
+    return UiKitView(
+      viewType: 'pdf_viewer_plugin',
+      onPlatformViewCreated: (int id) {},
+      gestureRecognizers: gestureRecognizers,
+      creationParams:
+          MethodChannelPdfViewerPlatform.creationParamsToMap(creationParams!),
+      creationParamsCodec: const StandardMessageCodec(),
+    );
+  }
+}

--- a/lib/src/pdf_viewer_method_channel.dart
+++ b/lib/src/pdf_viewer_method_channel.dart
@@ -1,0 +1,38 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+
+import '../pdf_viewer_plugin.dart';
+
+class MethodChannelPdfViewerPlatform  {
+  /// Constructs an instance that will listen for webviews broadcasting to the
+  /// given [id]
+  MethodChannelPdfViewerPlatform(int id)
+      : _channel = MethodChannel('pdf_viewer_plugin_$id') {
+    _channel.setMethodCallHandler(_onMethodCall);
+  }
+
+  final MethodChannel _channel;
+
+
+  Future<bool> _onMethodCall(MethodCall call) async {
+    throw MissingPluginException(
+      '${call.method} was invoked but has no handler',
+    );
+  }
+
+  /// Converts a [CreationParams] object to a map as expected by `platform_views` channel.
+  ///
+  /// This is used for the `creationParams` argument of the platform views created by
+  /// [AndroidPdfViewerBuilder] and [CupertinoPdfViewerBuilder].
+  static Map<String, dynamic> creationParamsToMap(
+      CreationParams creationParams) {
+    return <String, dynamic>{
+      'filePath': creationParams.path,
+    };
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.7.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,28 +66,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.4.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
+    version: "1.11.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,56 +99,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.1"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.4.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.12.13+hotfix.6 <2.0.0"
+  dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.12.13+hotfix.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pdf_viewer_plugin
 description: A Flutter plugin for IOS and Android providing a simple way to display local file PDFs (enter to see some gifs).
-version: 1.1.1
+version: 2.0.0
 homepage: https://github.com/lubritto/Pdf_Viewer_Plugin
 
 dependencies:
@@ -10,7 +10,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0+1
+  pedantic: ^1.11.1
 
 flutter:
   plugin:
@@ -22,5 +22,5 @@ flutter:
         pluginClass: PdfViewerPlugin
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.12.13+hotfix.6 <2.0.0" 


### PR DESCRIPTION
This pull request aims to bring null safety to the pdf_viewer_plugin.

I've been using the plugin for about one year now and I'm currently migrating my projects to null safety.
In this process I needed this plugin to be null safe as well… so I did it.

This pull request closes #47 .