### PR TITLE
Update Android PDF Viewer dependency version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,5 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation('com.github.barteksc:android-pdf-viewer:3.0.0-beta.4') {
-        force = true
-    }
+    implementation 'com.github.barteksc:AndroidPdfViewer:3.1.0-beta.1'
 }


### PR DESCRIPTION
The plugin depends on com.github.barteksc:AndroidPdfViewer:3.0.0-beta.4, but the latest available version is 3.1.0-beta.1 (published on JitPack).

Depending on the outdated 3.0.0-beta.4 version causes build conflicts and missing features available in the new version.